### PR TITLE
Fix NSE API: use GET instead of POST, fix cookie URL

### DIFF
--- a/openchart/core.py
+++ b/openchart/core.py
@@ -33,7 +33,7 @@ class NSEData:
         """Ensure NSE cookies are set for API access."""
         if not self._cookies_set:
             try:
-                self.session.get("https://www.nseindia.com", timeout=10)
+                self.session.get("https://charting.nseindia.com", timeout=10)
                 self._cookies_set = True
             except requests.exceptions.RequestException:
                 pass
@@ -65,7 +65,7 @@ class NSEData:
 
         try:
             payload = {"symbol": symbol, "segment": segment}
-            response = self.session.post(self.search_url, json=payload, timeout=10)
+            response = self.session.get(self.search_url, params=payload, timeout=10)
             response.raise_for_status()
             result = response.json()
 
@@ -142,7 +142,7 @@ class NSEData:
         }
 
         try:
-            response = self.session.post(self.historical_url, json=payload, timeout=10)
+            response = self.session.get(self.historical_url, params=payload, timeout=10)
             response.raise_for_status()
             result = response.json()
 

--- a/sample_historical.py
+++ b/sample_historical.py
@@ -1,28 +1,22 @@
 from openchart import NSEData
 import datetime
 
-# Initialize the NSEData class
 nse = NSEData()
 
-# Download master data for NSE and NFO
-nse.download()
-
-# Define the start and end dates (last 30 days)
 end_date = datetime.datetime.now()
-start_date = end_date - datetime.timedelta(days=30)
+start_date = end_date - datetime.timedelta(days=5)
 
-# Fetch 5-minute historical data for RELIANCE
+# Fetch 5-minute historical data for RELIANCE-EQ
 data = nse.historical(
-    symbol='RELIANCE',
-    exchange='NSE',
+    symbol='RELIANCE-EQ',
+    segment='EQ',
     start=start_date,
     end=end_date,
     interval='5m'
 )
 
-# Display the fetched data
 if not data.empty:
-    print("5-minute historical data for RELIANCE (Last 30 days):")
+    print("5-minute historical data for RELIANCE-EQ (Last 5 days):")
     print(data)
 else:
-    print("No data available for RELIANCE for the specified time period.")
+    print("No data available for RELIANCE-EQ for the specified time period.")


### PR DESCRIPTION
## Summary
The NSE charting API has changed - POST requests to the historical and search endpoints return empty data or incorrect results. The actual charting website uses GET requests.

## Changes
- **`_ensure_cookies`**: Changed from `www.nseindia.com` (returns 403) to `charting.nseindia.com`
- **`_fetch_historical`**: Changed from `session.post(url, json=payload)` to `session.get(url, params=payload)` - POST was returning `{"data":[]}`
- **`search`**: Changed from `session.post(url, json=payload)` to `session.get(url, params=payload)` - POST was ignoring the segment filter, always returning indices
- **`sample_historical.py`**: Updated deprecated API calls (`download()`, `exchange=` parameter had been removed in v0.2.0)

## Testing
All endpoints verified working for both indices (NIFTY 50) and equities (RELIANCE-EQ, INFY-EQ, HDFCBANK-EQ) across daily and 5-min intraday timeframes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the NSE charting integration by switching to GET requests and using the correct cookie domain. Restores working search and historical data for indices and equities.

- Bug Fixes
  - Set cookies via https://charting.nseindia.com instead of https://www.nseindia.com (403 on the latter).
  - Use GET with query params for search and historical endpoints; POST returned empty data and ignored the segment filter.
  - Update sample_historical.py: remove deprecated download(), replace exchange= with segment=, use symbols like RELIANCE-EQ, and narrow the sample date range.

<sup>Written for commit 1b524135d1c0cae1c577a8c00b7d20528143bf77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openchart/pull/13?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

